### PR TITLE
Fix upsert filter in AddSeasons

### DIFF
--- a/BallStats/api/AddSeasons.go
+++ b/BallStats/api/AddSeasons.go
@@ -87,7 +87,7 @@ func AddSeasons(startYear, endYear int) error {
 		}
 
 		for _, player := range players {
-			filter := bson.M{"id": player.ID}
+                       filter := bson.M{"_id": player.ID}
 			update := bson.M{"$set": bson.M{
 				"playername": player.PlayerName,
 				"position":   player.Position,


### PR DESCRIPTION
## Summary
- match documents by `_id` so updates find existing players

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*
- `go build ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f78e9149483208a0665e5137c3659