### PR TITLE
Add pytest and unit test for convert_epoch

### DIFF
--- a/Dynatrace/README.md
+++ b/Dynatrace/README.md
@@ -73,3 +73,7 @@ dynatrace_api_url=https://your-env.live.dynatrace.com
     uvicorn main:app --reload
     ```
 6.  **Visit the application**: Open your web browser and go to `http://127.0.0.1:8000/problems`.
+7.  **Run tests** (optional):
+    ```bash
+    pytest
+    ```

--- a/Dynatrace/requirements.txt
+++ b/Dynatrace/requirements.txt
@@ -3,3 +3,4 @@ requests
 pydantic
 python-dotenv
 jinja2
+pytest

--- a/Dynatrace/tests/test_dt_client.py
+++ b/Dynatrace/tests/test_dt_client.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import types
+
+# Ensure the Dynatrace package is on the path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Stub external dependencies so dt_client can be imported without them installed
+sys.modules.setdefault('requests', types.ModuleType('requests'))
+
+# Stub settings object required by dt_client
+dummy_settings = types.SimpleNamespace(dynatrace_api_url='', dynatrace_api_token='')
+config_stub = types.ModuleType('app.core.config')
+config_stub.settings = dummy_settings
+sys.modules['app.core.config'] = config_stub
+
+from app.core.dt_client import convert_epoch
+
+
+def test_convert_epoch_zero():
+    assert convert_epoch(0) == "1970-01-01 00:00:00"


### PR DESCRIPTION
## Summary
- add `pytest` to Dynatrace requirements
- document how to run tests in Dynatrace README
- create `tests/test_dt_client.py` with a unit test for `convert_epoch`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f78ed9f288320bf8a4519b728019f