### PR TITLE
Add test coverage and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f Dynatrace/requirements.txt ]; then pip install -r Dynatrace/requirements.txt; fi
+      - name: Run pytest
+        run: pytest
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Run Go tests
+        run: go test ./...

--- a/BallStats/db/cleanplayers_test.go
+++ b/BallStats/db/cleanplayers_test.go
@@ -1,0 +1,152 @@
+package db
+
+import (
+    "reflect"
+    "testing"
+
+    "go.mongodb.org/mongo-driver/bson"
+)
+
+func TestCreateSeasonFromData(t *testing.T) {
+    data := bson.M{
+        "season":            2024,
+        "age":               28,
+        "games":             82,
+        "minutesplayed":     2500,
+        "per":               15.5,
+        "tspercent":         0.55,
+        "threepar":          0.4,
+        "ftr":               0.3,
+        "offensiverbpercent": 5.0,
+        "defensiverbpercent": 10.0,
+        "totalrbpercent":    7.5,
+        "assistpercent":     20.5,
+        "stealpercent":      1.5,
+        "blockpercent":      0.6,
+        "turnoverpercent":   12.0,
+        "usagepercent":      15.0,
+        "offensivews":       2.1,
+        "defensivews":       1.2,
+        "winshares":         3.3,
+        "winsharesper":      0.1,
+        "offensivebox":      1.0,
+        "defensivebox":      -0.5,
+        "box":               0.5,
+        "vorp":              1.5,
+        "team":              "LAL",
+    }
+
+    want := Season{
+        SeasonYear:         2024,
+        Age:                28,
+        Games:              82,
+        MinutesPlayed:      2500,
+        PER:                15.5,
+        TSPercent:          0.55,
+        ThreePAr:           0.4,
+        FTr:                0.3,
+        OffensiveRBPercent: 5.0,
+        DefensiveRBPercent: 10.0,
+        TotalRBPercent:     7.5,
+        AssistPercent:      20.5,
+        StealPercent:       1.5,
+        BlockPercent:       0.6,
+        TurnoverPercent:    12.0,
+        UsagePercent:       15.0,
+        OffensiveWS:        2.1,
+        DefensiveWS:        1.2,
+        WinShares:          3.3,
+        WinSharesPer48:     0.1,
+        OffensiveBoxPlus:   1.0,
+        DefensiveBoxPlus:   -0.5,
+        BoxPlusMinus:       0.5,
+        VORP:               1.5,
+        Team:               "LAL",
+    }
+
+    got := createSeasonFromData(data)
+    if !reflect.DeepEqual(got, want) {
+        t.Errorf("got %+v, want %+v", got, want)
+    }
+}
+
+func TestCreatePlayerFromData(t *testing.T) {
+    playerData := []bson.M{
+        {
+            "playername":      "John Doe",
+            "position":        "G",
+            "season":          2024,
+            "age":             28,
+            "games":           82,
+            "minutesplayed":   2500,
+            "per":             15.5,
+            "tspercent":       0.55,
+            "threepar":        0.4,
+            "ftr":             0.3,
+            "offensiverbpercent": 5.0,
+            "defensiverbpercent": 10.0,
+            "totalrbpercent":  7.5,
+            "assistpercent":   20.5,
+            "stealpercent":    1.5,
+            "blockpercent":    0.6,
+            "turnoverpercent": 12.0,
+            "usagepercent":    15.0,
+            "offensivews":     2.1,
+            "defensivews":     1.2,
+            "winshares":       3.3,
+            "winsharesper":    0.1,
+            "offensivebox":    1.0,
+            "defensivebox":    -0.5,
+            "box":             0.5,
+            "vorp":            1.5,
+            "team":            "LAL",
+        },
+        {
+            "playername":      "John Doe",
+            "position":        "G",
+            "season":          2025,
+            "age":             29,
+            "games":           80,
+            "minutesplayed":   2400,
+            "per":             16.0,
+            "tspercent":       0.56,
+            "threepar":        0.41,
+            "ftr":             0.31,
+            "offensiverbpercent": 5.5,
+            "defensiverbpercent": 9.5,
+            "totalrbpercent":  7.0,
+            "assistpercent":   21.0,
+            "stealpercent":    1.6,
+            "blockpercent":    0.7,
+            "turnoverpercent": 11.5,
+            "usagepercent":    16.0,
+            "offensivews":     2.2,
+            "defensivews":     1.3,
+            "winshares":       3.5,
+            "winsharesper":    0.11,
+            "offensivebox":    1.1,
+            "defensivebox":    -0.4,
+            "box":             0.6,
+            "vorp":            1.6,
+            "team":            "LAL",
+        },
+    }
+
+    playerID := "123"
+    got := createPlayerFromData(playerID, playerData)
+
+    want := Player{
+        PlayerID:   "123",
+        PlayerName: "John Doe",
+        Position:   "G",
+        Seasons: []Season{
+            createSeasonFromData(playerData[0]),
+            createSeasonFromData(playerData[1]),
+        },
+    }
+
+    if !reflect.DeepEqual(got, want) {
+        t.Errorf("got %+v, want %+v", got, want)
+    }
+}
+

--- a/Dynatrace/tests/test_dt_client.py
+++ b/Dynatrace/tests/test_dt_client.py
@@ -19,3 +19,24 @@ from app.core.dt_client import convert_epoch
 
 def test_convert_epoch_zero():
     assert convert_epoch(0) == "1970-01-01 00:00:00"
+
+
+def test_get_problems(monkeypatch):
+    from app.core import dt_client
+
+    dummy_response = types.SimpleNamespace(
+        json=lambda: {"problems": [{"id": "p1"}]},
+        raise_for_status=lambda: None,
+    )
+
+    def fake_get(url, headers=None, params=None):
+        return dummy_response
+
+    monkeypatch.setattr(dt_client, "settings", types.SimpleNamespace(
+        dynatrace_api_url="http://example.com",
+        dynatrace_api_token="token",
+    ))
+    monkeypatch.setattr(dt_client.requests, "get", fake_get)
+
+    problems = dt_client.get_problems()
+    assert problems == [{"id": "p1"}]

--- a/PickEm/tests/test_core.py
+++ b/PickEm/tests/test_core.py
@@ -1,0 +1,71 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import types
+sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+sys.modules.setdefault("tabulate", types.ModuleType("tabulate"))
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+sys.modules["tabulate"].tabulate = lambda *a, **k: ""
+sys.modules["requests"].get = lambda *a, **k: types.SimpleNamespace(json=lambda: {"data": []})
+
+from GetStats import is_triple_double
+from CleanupLines import get_projection_info, filter_included_data
+
+
+def test_is_triple_double_true():
+    game = {"pts": 10, "reb": 10, "ast": 10, "stl": 0, "blk": 0}
+    assert is_triple_double(game) is True
+
+
+def test_is_triple_double_false():
+    game = {"pts": 10, "reb": 9, "ast": 10, "stl": 0, "blk": 0}
+    assert is_triple_double(game) is False
+
+
+def test_get_projection_info():
+    projection = {
+        "attributes": {
+            "rank": 1,
+            "description": "foo",
+            "line_score": 20,
+            "stat_type": "PTS",
+        },
+        "relationships": {"new_player": {"data": {"id": "42"}}},
+    }
+    players = {
+        "42": {
+            "attributes": {
+                "market": "NBA",
+                "name": "John Doe",
+                "position": "G",
+                "team_name": "LAL",
+                "team_logo": "logo",
+                "player_headshot": "head",
+            }
+        }
+    }
+    expected = {
+        "rank": 1,
+        "description": "foo",
+        "line_score": 20,
+        "stat_type": "PTS",
+        "new_player_id": "42",
+        "market": "NBA",
+        "name": "John Doe",
+        "position": "G",
+        "team_name": "LAL",
+        "team_logo": "logo",
+        "player_headshot": "head",
+    }
+    assert get_projection_info(projection, players) == expected
+
+
+def test_filter_included_data():
+    data = {
+        "included": [
+            {"type": "new_player", "id": "1"},
+            {"type": "other", "id": "x"},
+        ]
+    }
+    result = filter_included_data(data, "new_player")
+    assert result == [{"type": "new_player", "id": "1"}]


### PR DESCRIPTION
## Summary
- add CI workflow running pytest and go tests
- add unit tests for `dt_client.get_problems`
- add Go unit tests for BallStats helpers
- add PickEm unit tests for key helper functions

## Testing
- `go test ./...` *(fails: Forbidden)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8644608083208791d778f0d5735a