### PR TITLE
Add audit log fetcher script

### DIFF
--- a/Dynatrace/README.md
+++ b/Dynatrace/README.md
@@ -15,6 +15,7 @@ A FastAPI-based web application that displays recent problems from a Dynatrace e
 * **Epoch time conversion**: Automatically converts raw epoch timestamps to human-readable UTC.
 * **Direct links to Dynatrace UI**: Quickly navigate to the problem detail pages within your Dynatrace environment.
 * **Static file support**: Includes CSS for a visually appealing interface.
+* **Audit log fetcher script**: `fetch_audit_logs.py` downloads the last 24 hours of audit logs and writes them to `audit_logs.csv`.
 
 ---
 

--- a/Dynatrace/fetch_audit_logs.py
+++ b/Dynatrace/fetch_audit_logs.py
@@ -1,0 +1,30 @@
+import csv
+from datetime import datetime, timedelta, timezone
+
+from app.core.dt_client import get_audit_logs
+
+
+def main():
+    now = datetime.now(timezone.utc)
+    start = int((now - timedelta(days=1)).timestamp() * 1000)
+    end = int(now.timestamp() * 1000)
+
+    logs = get_audit_logs(start, end)
+    if not logs:
+        print("No audit logs found")
+        return
+
+    keys = list(logs[0].keys())
+
+    for log in logs:
+        print(" | ".join(f"{k}={log.get(k)}" for k in keys))
+
+    with open("audit_logs.csv", "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=keys)
+        writer.writeheader()
+        writer.writerows(logs)
+    print("Saved audit_logs.csv")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- fix dt_client trailing prompt artifacts
- add get_audit_logs helper
- provide a `fetch_audit_logs.py` script to dump logs to CSV
- update Dynatrace README
- extend tests for new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683faffae2d8832090034fc4cd09c5ef