### PR TITLE
Integrate audit log fetch into web app

### DIFF
--- a/Dynatrace/README.md
+++ b/Dynatrace/README.md
@@ -15,7 +15,7 @@ A FastAPI-based web application that displays recent problems from a Dynatrace e
 * **Epoch time conversion**: Automatically converts raw epoch timestamps to human-readable UTC.
 * **Direct links to Dynatrace UI**: Quickly navigate to the problem detail pages within your Dynatrace environment.
 * **Static file support**: Includes CSS for a visually appealing interface.
-* **Audit log fetcher script**: `fetch_audit_logs.py` downloads the last 24 hours of audit logs and writes them to `audit_logs.csv`.
+* **Audit log endpoint**: `/audit-logs` returns the last 24 hours of audit logs in JSON format. The standalone script `fetch_audit_logs.py` is still available for saving logs to a CSV file.
 
 ---
 

--- a/Dynatrace/app/api/audit_logs.py
+++ b/Dynatrace/app/api/audit_logs.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timedelta, timezone
+from fastapi import APIRouter
+
+from app.core.dt_client import get_audit_logs
+
+router = APIRouter()
+
+@router.get("/audit-logs")
+def audit_logs():
+    """Return the last 24 hours of audit logs as JSON."""
+    now = datetime.now(timezone.utc)
+    start = int((now - timedelta(days=1)).timestamp() * 1000)
+    end = int(now.timestamp() * 1000)
+
+    logs = get_audit_logs(start, end)
+    return logs or []

--- a/Dynatrace/main.py
+++ b/Dynatrace/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from app.api import problems
+from app.api import problems, audit_logs
 from app.core.config import settings
 from fastapi.staticfiles import StaticFiles
 app = FastAPI()
@@ -12,6 +12,7 @@ def read_root():
     return {"message": "Dynatrace Self-Service Tower Running"}
 
 app.include_router(problems.router)
+app.include_router(audit_logs.router)
 
 def dynalink(problem_id):
     return f"{settings.dynatrace_api_url}/ui/problems/{problem_id}"


### PR DESCRIPTION
## Summary
- add `/audit-logs` endpoint returning last day's audit logs
- include new router in main application
- update documentation for new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb276ec1c832094fb0b8a3c93cfc8