### PR TITLE
Add poker simulator with route and tests

### DIFF
--- a/PokerGTO/README.md
+++ b/PokerGTO/README.md
@@ -24,3 +24,14 @@ python app.py
 ```
 
 Visit `http://127.0.0.1:5000/` in your browser.
+
+## Simulating Hands
+
+To deal random starting hands, visit the `/simulate` route. You can optionally
+specify the number of players with the `players` query parameter:
+
+```
+http://127.0.0.1:5000/simulate?players=4
+```
+
+Each request shuffles a new deck and displays two cards for every player.

--- a/PokerGTO/app.py
+++ b/PokerGTO/app.py
@@ -1,6 +1,8 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 import json
 from pathlib import Path
+
+import simulator
 
 app = Flask(__name__)
 
@@ -21,6 +23,19 @@ def index():
 def ranges():
     ranges = load_ranges()
     return render_template('ranges.html', ranges=ranges)
+
+
+@app.route('/simulate')
+def simulate():
+    try:
+        num_players = int(request.args.get('players', 2))
+    except ValueError:
+        num_players = 2
+
+    table = simulator.PokerTable(num_players)
+    table.shuffle()
+    players = table.deal_hands()
+    return render_template('simulate.html', players=players)
 
 
 if __name__ == '__main__':

--- a/PokerGTO/simulator.py
+++ b/PokerGTO/simulator.py
@@ -1,0 +1,50 @@
+class Card:
+    SUITS = ['Hearts', 'Diamonds', 'Clubs', 'Spades']
+    VALUES = ['2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K', 'A']
+
+    def __init__(self, value, suit):
+        self.value = value
+        self.suit = suit
+
+    def __repr__(self):
+        return f"{self.value}{self.suit[0]}"
+
+
+class Deck:
+    def __init__(self):
+        self.cards = [Card(v, s) for s in Card.SUITS for v in Card.VALUES]
+
+    def shuffle(self, rng=None):
+        import random
+        rand = rng or random
+        rand.shuffle(self.cards)
+
+    def deal_card(self):
+        return self.cards.pop()
+
+    def __len__(self):
+        return len(self.cards)
+
+
+class Player:
+    def __init__(self, name):
+        self.name = name
+        self.hand = []
+
+    def receive(self, card):
+        self.hand.append(card)
+
+
+class PokerTable:
+    def __init__(self, num_players):
+        self.deck = Deck()
+        self.players = [Player(f"Player {i+1}") for i in range(num_players)]
+
+    def shuffle(self, rng=None):
+        self.deck.shuffle(rng)
+
+    def deal_hands(self, cards_per_player=2):
+        for _ in range(cards_per_player):
+            for player in self.players:
+                player.receive(self.deck.deal_card())
+        return self.players

--- a/PokerGTO/templates/simulate.html
+++ b/PokerGTO/templates/simulate.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Simulated Hands</h2>
+<ul>
+    {% for player in players %}
+    <li><strong>{{ player.name }}:</strong> {{ player.hand[0] }}, {{ player.hand[1] }}</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/PokerGTO/tests/test_simulator.py
+++ b/PokerGTO/tests/test_simulator.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import simulator
+
+
+def test_deck_shuffle_changes_order():
+    deck = simulator.Deck()
+    original_order = deck.cards.copy()
+    deck.shuffle()
+    shuffled_order = deck.cards
+    assert len(shuffled_order) == 52
+    # ensure at least one card moved
+    assert shuffled_order != original_order
+    assert sorted(repr(c) for c in shuffled_order) == sorted(repr(c) for c in original_order)
+
+
+def test_deal_hands_unique_cards():
+    table = simulator.PokerTable(4)
+    table.shuffle()
+    players = table.deal_hands()
+    dealt_cards = [card for p in players for card in p.hand]
+    assert len(dealt_cards) == 8
+    assert len(set(map(repr, dealt_cards))) == 8
+    assert len(table.deck) == 52 - 8


### PR DESCRIPTION
## Summary
- implement basic poker simulator classes
- expose `/simulate` endpoint to deal hands
- render hands in new template
- document simulator usage
- test shuffling and dealing logic

## Testing
- `pytest PokerGTO/tests/test_simulator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb366b5fc8320b125b495f5754c80