### PR TITLE
Add logistic ML prediction service

### DIFF
--- a/PickEm/ml_prediction_service.py
+++ b/PickEm/ml_prediction_service.py
@@ -1,0 +1,99 @@
+import csv
+import json
+import math
+import argparse
+from pathlib import Path
+from collections import defaultdict
+
+from simple_prediction_service import _float, compute_actual
+
+
+def build_dataset(rows):
+    features = []
+    labels = []
+    meta = []
+    for row in rows:
+        actual = compute_actual(row)
+        if actual is None:
+            continue
+        line_score = _float(row.get("Line Score"))
+        x = [
+            line_score,
+            _float(row.get("PTS")),
+            _float(row.get("REB")),
+            _float(row.get("AST")),
+        ]
+        y = 1 if actual > line_score else 0
+        features.append(x)
+        labels.append(y)
+        meta.append((row.get("Player Name"), row.get("Stat Type")))
+    return features, labels, meta
+
+
+def logistic_train(X, y, lr=0.01, epochs=500):
+    if not X:
+        return [], 0.0
+    weights = [0.0] * len(X[0])
+    bias = 0.0
+    for _ in range(epochs):
+        for xi, yi in zip(X, y):
+            z = bias + sum(w * x for w, x in zip(weights, xi))
+            pred = 1.0 / (1.0 + math.exp(-z))
+            error = pred - yi
+            for j in range(len(weights)):
+                weights[j] -= lr * error * xi[j]
+            bias -= lr * error
+    return weights, bias
+
+
+def logistic_predict(X, weights, bias):
+    preds = []
+    for xi in X:
+        z = bias + sum(w * x for w, x in zip(weights, xi))
+        p = 1.0 / (1.0 + math.exp(-z))
+        preds.append(p)
+    return preds
+
+
+def aggregate_predictions(meta, preds):
+    results = defaultdict(lambda: {"player": None, "stat_type": None, "games": 0, "over": 0, "under": 0})
+    for (player, stat), p in zip(meta, preds):
+        entry = results[(player, stat)]
+        entry["player"], entry["stat_type"] = player, stat
+        entry["games"] += 1
+        if p >= 0.5:
+            entry["over"] += 1
+        else:
+            entry["under"] += 1
+    for entry in results.values():
+        games = entry["games"] or 1
+        entry["over_pct"] = round(entry["over"] / games, 2)
+    return list(results.values())
+
+
+def load_data(csv_file):
+    with open(csv_file, newline='', encoding='utf-8') as f:
+        return list(csv.DictReader(f))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train logistic model for over/under predictions")
+    default_csv = Path(__file__).resolve().parent / 'combined_data.csv'
+    parser.add_argument('--csv', default=str(default_csv))
+    parser.add_argument('--output', default='ml_predictions.json')
+    parser.add_argument('--epochs', type=int, default=500)
+    args = parser.parse_args()
+
+    rows = load_data(args.csv)
+    X, y, meta = build_dataset(rows)
+    weights, bias = logistic_train(X, y, epochs=args.epochs)
+    preds = logistic_predict(X, weights, bias)
+    results = aggregate_predictions(meta, preds)
+
+    with open(args.output, 'w', encoding='utf-8') as f:
+        json.dump(results, f, indent=2)
+    print(f"Saved {len(results)} predictions to {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/PickEm/readme.md
+++ b/PickEm/readme.md
@@ -49,7 +49,13 @@ python predictive_model_script.py
 
 Interpret the classification metrics to gauge model quality—higher precision and recall indicate better predictions. Use the aggregated prediction table to spot players with frequent predicted overs or unders.
 
-## 7. Visualize and explore
+## 7. Simple Prediction Service
+Run `python simple_prediction_service.py` to aggregate historical overs and unders and save to `simple_predictions.json`. The script automatically reads `combined_data.csv` from the same folder so it works whether you call it from the repository root or the `PickEm` directory.
+
+## 8. Machine Learning Prediction Service
+Run `python ml_prediction_service.py` to train a lightweight logistic regression model and output aggregated predictions to `ml_predictions.json`.
+
+## 9. Visualize and explore
 Run `ShowMetheMoney.py` to explore the merged dataset with additional summaries and graphs. The script uses seaborn and matplotlib to display trends.
 
 ```bash

--- a/PickEm/simple_prediction_service.py
+++ b/PickEm/simple_prediction_service.py
@@ -1,0 +1,80 @@
+import csv
+import json
+import argparse
+from pathlib import Path
+from collections import defaultdict
+
+
+def load_data(csv_file):
+    with open(csv_file, newline='', encoding='utf-8') as f:
+        return list(csv.DictReader(f))
+
+
+def _float(value):
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def compute_actual(row):
+    stat = row.get("Stat Type", "")
+    pts = _float(row.get("PTS"))
+    reb = _float(row.get("REB"))
+    ast = _float(row.get("AST"))
+
+    if stat == "PTS":
+        return pts
+    if stat == "REB":
+        return reb
+    if stat == "AST":
+        return ast
+    if "Pts+Rebs+Asts" in stat or stat == "PRA":
+        return pts + reb + ast
+    if "Pts+Rebs" in stat:
+        return pts + reb
+    if "Pts+Asts" in stat:
+        return pts + ast
+    if "Rebs+Asts" in stat:
+        return reb + ast
+    return None
+
+
+def aggregate_predictions(rows):
+    results = defaultdict(lambda: {"player": None, "stat_type": None, "games": 0, "over": 0, "under": 0})
+    for row in rows:
+        actual = compute_actual(row)
+        if actual is None:
+            continue
+        line_score = _float(row.get("Line Score"))
+        key = (row.get("Player Name"), row.get("Stat Type"))
+        entry = results[key]
+        entry["player"], entry["stat_type"] = key
+        entry["games"] += 1
+        if actual > line_score:
+            entry["over"] += 1
+        else:
+            entry["under"] += 1
+    for entry in results.values():
+        games = entry["games"] or 1
+        entry["over_pct"] = round(entry["over"] / games, 2)
+    return list(results.values())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate simple over/under predictions")
+    default_csv = Path(__file__).resolve().parent / 'combined_data.csv'
+    parser.add_argument('--csv', default=str(default_csv))
+    parser.add_argument('--output', default='simple_predictions.json')
+    args = parser.parse_args()
+
+    rows = load_data(args.csv)
+    results = aggregate_predictions(rows)
+
+    with open(args.output, 'w', encoding='utf-8') as f:
+        json.dump(results, f, indent=2)
+    print(f"Saved {len(results)} predictions to {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/PickEm/tests/test_ml_prediction_service.py
+++ b/PickEm/tests/test_ml_prediction_service.py
@@ -1,0 +1,10 @@
+from ml_prediction_service import logistic_train, logistic_predict
+
+
+def test_logistic_train_predict_shape():
+    X = [[0], [1], [2], [3]]
+    y = [0, 0, 1, 1]
+    weights, bias = logistic_train(X, y, epochs=50, lr=0.1)
+    preds = logistic_predict(X, weights, bias)
+    assert len(preds) == 4
+    assert all(0 <= p <= 1 for p in preds)

--- a/PickEm/tests/test_simple_prediction_service.py
+++ b/PickEm/tests/test_simple_prediction_service.py
@@ -1,0 +1,29 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from simple_prediction_service import compute_actual, aggregate_predictions
+
+
+def test_compute_actual_pts():
+    row = {"Stat Type": "PTS", "PTS": "25"}
+    assert compute_actual(row) == 25
+
+
+def test_compute_actual_combo():
+    row = {"Stat Type": "Pts+Rebs+Asts", "PTS": "10", "REB": "5", "AST": "5"}
+    assert compute_actual(row) == 20
+
+
+def test_aggregate_predictions():
+    rows = [
+        {"Player Name": "John", "Stat Type": "PTS", "PTS": "15", "Line Score": "10"},
+        {"Player Name": "John", "Stat Type": "PTS", "PTS": "8", "Line Score": "10"},
+    ]
+    agg = aggregate_predictions(rows)
+    assert len(agg) == 1
+    result = agg[0]
+    assert result["games"] == 2
+    assert result["over"] == 1
+    assert result["under"] == 1
+    assert result["over_pct"] == 0.5

--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ A suite of Python scripts, datasets, and simple GUI tools for NBA “Pick ’Em�
 
 - **Data gathering**: `GatherCurrentNBA*.py`, `GetStats.py`, `GetMatchups.py`  
 - **Cleaning & merging**: `CleanupLines.py`, `Mergetest.py`, `Merge*`  
-- **Analytics & modeling**: `predictive_model_script.py`, `ShowMetheMoney.py`  
-- **GUI exploration**: `Gui.py`  
+- **Analytics & modeling**: `predictive_model_script.py`, `ShowMetheMoney.py`
+- **Simple predictions**: `simple_prediction_service.py` aggregates historical overs and unders from `combined_data.csv`
+- **ML predictions**: `ml_prediction_service.py` trains a lightweight logistic model for over/under forecasts
+- **GUI exploration**: `Gui.py`
 - **Datasets**: CSVs, JSON game logs, PrizePicks API extracts  
 - **Technologies**: Python, pandas, JSON/CSV, tkinter, basic machine learning  
 


### PR DESCRIPTION
## Summary
- implement `ml_prediction_service.py` that trains a simple logistic regression model without external dependencies
- document the new script in the project readmes
- test gradient-descent training and prediction

## Testing
- `pytest -q`
- `go test ./...` *(fails: directory prefix does not contain module)*

------
https://chatgpt.com/codex/tasks/task_e_68830f39f364832091f03dca502fb582